### PR TITLE
Add minimal required cmake version into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ current [project's CMakeLists.txt](https://github.com/gangliao/bazel.cmake/blob/
 
 ```cmake
 # CMakeLists.txt
+cmake_minimum_required(VERSION 3.11)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/bazel.cmake/cmake)
 include(bazel)
 ```


### PR DESCRIPTION
This change was inspired by https://github.com/gangliao/bazel.cmake/issues/26